### PR TITLE
Initialization of array params not needed

### DIFF
--- a/src/Component/Security/Http/Signature/DefaultSignature.php
+++ b/src/Component/Security/Http/Signature/DefaultSignature.php
@@ -26,8 +26,7 @@ class DefaultSignature implements SignatureInterface
     public function sign($url, $key)
     {
         $endpoint = http_build_url($url, [], HTTP_URL_STRIP_QUERY | HTTP_URL_STRIP_FRAGMENT);
-
-        $params = [];
+        //$params = [];
 
         if (strpos($url, '?') !== false) {
             parse_str(parse_url($url, PHP_URL_QUERY), $params);


### PR DESCRIPTION
If we initialize the array of params the following code is all wrong 
the code only takes the endpoint to create the signature.
the generation is all wrong
Need to change de documentation exemple with the sign key exemple that is all wrong
